### PR TITLE
Improve Monorepo Support

### DIFF
--- a/sources/commands/link.ts
+++ b/sources/commands/link.ts
@@ -62,7 +62,7 @@ export default class LinkCommand extends BaseCommand {
         workspaceCwd,
         info: await loadDependencyInfo(ppath.join(workspaceCwd, 'bsconfig.json' as Filename))
       }))
-    ).then(arr => arr.filter(Boolean));
+    ).then(arr => arr.filter(v => v.info != null));
 
     if (resDependencyInfos.length === 0) {
       console.log('TODO: res init first');


### PR DESCRIPTION
This PR improves the `link` command used in Monorepo setups.

Notable changes are:
- Now fetches dependencies not only from the root `bsconfig.json`, but ones from workspace members.
- Workspace members are symlinked into `node_modules` when it's listed inside the ReScript dependency list.

It doesn't handle duplicate dependencies in any clever way so it could be improved later.